### PR TITLE
Fix: Adjust footer position in iOS full-screen mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -95,3 +95,9 @@ input.ui-slider-input {
     margin-top: 0 !important;
 }
 
+/* Adjust footer for iOS full-screen mode */
+@media (display-mode: standalone) {
+    footer {
+        bottom: 5px;
+    }
+}


### PR DESCRIPTION
The footer was positioned too low when the application is running in full-screen mode on iOS devices. This change adds a media query to target standalone display mode and adjusts the `bottom` property of the footer to `5px`, moving it up to a more appropriate position.